### PR TITLE
docs: add config key to README example for easier copy-pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,18 @@ config: {
   profiles: [
     {
       name: "One Dark",
-      colors: {
-        // ...
+      config: {
+        colors: {
+          // ...
+        },
       },
     },
     {
       name: "One Light",
-      colors: {
-        // ...
+      config: {
+        colors: {
+          // ...
+        },
       },
     },
   ];


### PR DESCRIPTION
Hi João

Thanks for writing this small, but helpful hyper plugin.

I noticed that the example in the README does not work out-of-the-box, so I quickly threw together this PR. I hope it helps!

Regards
Stefan

PS: I wanted to keep this PR minimal. The example could be further enhanced example by adding more keys users would want to set (e.g. `config.backgroundColor`, `config.foregroundColor`, …).